### PR TITLE
First brush-up of sanitization code

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,31 +58,31 @@ it can be executed:
     py.test --ipynb my_notebook.ipynb
 
 for an specific notebook. 
-If the output lines are going to be sanitized, an extra flag, `--sanitize-file`
+If the output lines are going to be sanitized, an extra flag, `--sanitize-with`
 together with the path to a confguration file with regex expressions, must be passed,
 i.e.
 
-    py.test --ipynb my_notebook.ipynb --sanitize-file path/to/my_sanitize_file
+    py.test --ipynb my_notebook.ipynb --sanitize-with path/to/my_sanitize_file
 
-where `my_sanitize_file` has the structure
+where `my_sanitize_file` has the following structure.
 
 ```
-[regex1]
+[Section1]
 regex: [a-z]* 
 replace: abcd
 
-[regex2]
 regex: [1-9]*
 replace: 0000
+
+[Section2]
+regex: foo
+replace: bar
 ```
 
 The `regex` option contains the expression that is going to be matched in the outputs, and
 `replace` is the string that will replace the `regex` match. Currently, the section
 names do not have any meaning or influence in the testing system, it will take
 all the sections and replace the corresponding options.
-
-Examples of a notebook and regex file are found in the `finmag_nb_test.ipynb`
-and `regex_sanitize` files, correspondingly.
 
 ## Help
 The `py.test` system help can be obtained with `py.test -h`, which will

--- a/documentation.ipynb
+++ b/documentation.ipynb
@@ -51,7 +51,7 @@
    "source": [
     "Since all output is captured by the IPython notebook, some pesky messages and prompts (with time-stamped messages, for example) may fail tests always, which might be expected. The plugin allows the user to specify a sanitizing file at the command prompt using the following flag:\n",
     "```\n",
-    "$ py.test --ipynb my_notebook.ipynb --sanitize-file my_sanitize\n",
+    "$ py.test --ipynb my_notebook.ipynb --sanitize-with my_sanitize_file\n",
     "```\n",
     "\n",
     "This sanitize file contains a number of REGEX replacements. It is recommended, when removing output for the tests, that you replace the removed output with some sort of marker, this helps with debugging. The following file is written to the folder of this notebook and can be used to santize its outputs:"
@@ -68,12 +68,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Overwriting doc_sanitize\n"
+      "Writing doc_sanitize.cfg\n"
      ]
     }
    ],
    "source": [
-    "%%writefile doc_sanitize\n",
+    "%%writefile doc_sanitize.cfg\n",
     "[regex1]\n",
     "regex: \\d{1,2}/\\d{1,2}/\\d{2,4}\n",
     "replace: DATE-STAMP\n",
@@ -104,7 +104,7 @@
     "You can validate this notebook yourself, as shown below; the outputs that you see here are stored in the ipynb file. If your system produces different outputs, the testing process will fail. Just use the following commands:\n",
     "```\n",
     "$ cd /path/to/this/notebook\n",
-    "$ py.test --ipynb documentation.ipynb --sanitize-file doc_sanitize\n",
+    "$ py.test --ipynb documentation.ipynb --sanitize-with doc_sanitize.cfg\n",
     "```"
    ]
   },
@@ -229,7 +229,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Because the **time and date** will change with each run, we would expect this cell to fail everytime. Using the sanitize file `doc_sanitize` (created above) you can clean up these outputs."
+    "Because the **time and date** will change with each run, we would expect this cell to fail everytime. Using the sanitize file `doc_sanitize.cfg` (created above) you can clean up these outputs."
    ]
   },
   {

--- a/pytest_validate_nb/plugin.py
+++ b/pytest_validate_nb/plugin.py
@@ -53,7 +53,7 @@ def pytest_addoption(parser):
     group.addoption('--ipynb', action='store_true',
                     help="Validate IPython notebooks")
 
-    group.addoption('--sanitize-file',
+    group.addoption('--sanitize-with',
                     help='File with regex expressions to sanitize '
                          'the outputs. This option only works when '
                          'the --ipynb flag is passed to py.test')
@@ -172,8 +172,8 @@ class IPyNbFile(pytest.File):
               this is likely to change in the future
 
         """
-        if self.parent.config.option.sanitize_file is not None:
-            return [self.parent.config.option.sanitize_file]
+        if self.parent.config.option.sanitize_with is not None:
+            return [self.parent.config.option.sanitize_with]
         else:
             return []
 

--- a/pytest_validate_nb/plugin.py
+++ b/pytest_validate_nb/plugin.py
@@ -500,3 +500,19 @@ class IPyNbCell(pytest.Item):
                            s)
 
         return s
+
+
+def read_sanitize_patterns(string):
+    """
+    *Arguments*
+
+    string:  str
+
+        String containing a list of regex-replace pairs as would be
+        read from a sanitize config file.
+    """
+    matches = re.findall('^regex: (.*)$\n^replace: (.*)$',
+                         string,
+                         flags=re.MULTILINE)
+    pats = {key: val for (key, val) in matches}
+    return pats

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -5,5 +5,6 @@ all: test
 
 test:
 	$(PYTEST) $(TEST_OPTIONS) .
+	$(PYTEST) --ipynb --sanitize-with sanitize_defaults.cfg sample_notebook.ipynb
 
 .PHONY: all test

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,9 @@
+PYTEST ?= py.test
+TEST_OPTIONS ?= -sv
+
+all: test
+
+test:
+	$(PYTEST) $(TEST_OPTIONS) .
+
+.PHONY: all test

--- a/tests/minimal_example.ipynb
+++ b/tests/minimal_example.ipynb
@@ -1,0 +1,60 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Minimal example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Hello world!\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Hello world!\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/tests/sample_notebook.ipynb
+++ b/tests/sample_notebook.ipynb
@@ -1,0 +1,172 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Sample notebook"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is a sample notebook which can be used to test the `py.test --ipynb` plugin."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Hello world\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Hello world\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from datetime import datetime"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "datetime.datetime(2015, 4, 8, 14, 17, 21, 527210)"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# PYTEST_VALIDATE_IGNORE_OUTPUT\n",
+    "datetime.now()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'Last executed: 2015-04-08, 14:30:02'"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#datetime.today().strftime(\"%a %y %b %Y, %H:%M:%S\")\n",
+    "datetime.today().strftime(\"Last executed: %Y-%m-%d, %H:%M:%S\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.legend.Legend at 0xb9480ac>"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYgAAAEZCAYAAACNebLAAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAHbFJREFUeJzt3XvUXXV95/H3hwASDSOgIyi5MHLRuoICMlwKNRE7lEQH\nnJlaWkfg0FUKDgYGW9vC0gHstKWudpRAWy5yt4jojIByswgp3rgMECFyEQRDTCHqBCpXQfKdP/YO\nOTk553n2OWffz+e11rM4l/3s880meX7P7/fdn70VEZiZmfXarOoCzMysnjxAmJlZXx4gzMysLw8Q\nZmbWlwcIMzPrywOEmZn15QHCWk3ShyXdUNC+L5L06QL2e5Skb+W9X7NheYCwxpN0oKTvSHpa0s8l\nfUvSuwEi4vKIOKTqGkeQKaAk6RZJv190MTaZNq+6ALNxSNoa+BpwLPBlYEvgN4BfVlmXWRt4BmFN\ntxsQEXFlJH4ZETdFxArYdLlG0jpJH5X0sKR/lfRpSW+V9F1JT0n6oqTN020XSFol6WRJP5P0qKQP\nDypE0gck3ZPu59uSdp9i23WSlkj6kaSfSvrMFNv+uqQ70v3eLmn/9PX/STIYni3pF5KWDn30zKbg\nAcKa7ofAK5IulnSIpG36bNO7XHMwsAewH/AnwPnA7wFzgXemj9fbAdgOeAvQAc6TtGvvB0jaE7gA\nOCbd/lzgGklbTFH7B4G90q/D+i0VSdoW+DrwOeANwGeBayVtGxGfBL4FfCwi/k1EnDDFZ5kNzQOE\nNVpEPAMcCKwDzgN+KulqSf92im/764h4LiIeAFYAN0TEynRf1wN7dn8E8KmIeDkibgWuBX6nzz6P\nAc6JiP+bzmQuI1nm2m+KOs6IiH+NiJ+QDAC/12eb9wM/THsp6yLiCuBB4D9OsV+zXHiAsMaLiIci\n4vcjYi4wn+S3/c9N8S0/7Xr8ArCm5/msrudPRcSLXc9XpvvvNQ/4I0lr06+ngNkDtl3vJxn2+5b0\nPXq23XGK/ZrlwgOEtUpE/BC4mGSgyMO2kmZ2PZ8L/Euf7VYBfxER26Vf20bErIj40hT7npNhv/8C\n7NTz2lxgdfrYl2O2wniAsEaT9DZJH5e0Y/p8DslSzffy+gjgdElbSPoNkiWfK/tsdz5wnKR90jpe\nJ2mxpNdNse9PSNomrflE4Io+21wH7CrpdyXNkHQ48GskfQlIZj9vHe2PZjY1DxDWdM8A+wK3S3oG\n+C5wL/DHA7bv/Y17ut/AnwCeIvlN/jLg2Ih4uPd7I+Iukj7E2ZLWkjTPj5pm31cDdwF3k5yqe+Em\nxUasBT5A8uf5efrf96evA5wJfEjS/5M01bKa2dBU5A2DJL0GuJXk3PQtgasj4pQ+2y0FFgHPAZ2I\nWF5YUWYZSVoAXJb2NvLe9zpgl4h4NO99m+Wl0KBcRPxS0nsj4nlJM4DvSDogIr6zfhtJi4CdI2JX\nSfsC5zD1mR9mZlaCwpeYIuL59OFr0s97qmeTw4BL021vB14vafui6zKrmJvLVnuFDxCSNpN0D/Ak\nsCwi7u/ZZEeSM0DWW41P4bMaiIh/LmJ5Kd33DC8vWd2VMYNYFxF7kpwT/p50XdfMzGqutIv1RcQv\nJF0L7A38c9dbq9n4fPDZbDjH+1WSPCU3MxtBRGjUbyzsC3gj8Pr08UySM5re17PNYuDa9PF+wG0D\n9hVF1prjn/m0qmsYXNshN0BE8nVqbHi86Pqqa2vi8WxanU2o0XUWUmeM+r1FLzG9Gbgl7UHcBlwT\nEd+UdKykP0wrvw54TNIjJBc4+28F1zTBVi2FP3l+49f++Hl4/Kxq6jGzOiv6NNf7SK5U2fv6uT3P\nP1ZkHbbeinvh5lfgA/8ED+0Gdz4Ex8+Fv3k7SWLXzOxVvmFQ/pZVXcAUjoCDLo846DhJCyMeXiYx\nD7hD4rsR3FZ1gX0sq7qAjJZVXUAGy6ouIKNlVReQ0bKqCyhaoUnqPEmKGLXRYkiI5DLRR/UOBBKH\nAkuBvSJY2+/7zayZxvnZ6RnE5NiPJJx1e+8bEVwjsQC4WOKwCIe4rBqSfkxy6XQb3sqI2CnPHXoG\nMSEkzgUei+CMAe9vSXKW2ZUR/K9SizNL+d/56AYdu3GOqQeICSAxkyRbsnvEphmTru3mAXcAh9W0\nH2Et53/noytigPDlvifDB4E7phocACJYSXLJ6isktiulMjOrLQ8Qk6FDcpe1aUVwDfC/SfoR/k3O\nbIJ5gGg5idkklze5eohvOxl4E3BSIUWZ2ZQkzZO0TlKlP6N9FlP7HQF8OYIXsn5DBC9JHE698xFm\nbVd5g9gDRIulS0Qdpr/15SYiWCm92o9wPsIqJ81fDHNOgK23gmdehFVLI1YMdQWAPPaR7XM0IyJe\nyXu/ZfMA0W4Dsw9ZOB9hdZH8YN//TDh/lw2vHrOzNJ+sP+Dz2Yf2Aj4P7AzcCKwjuf/4N4EvAGeR\nLM1+Q9KJJPcx3xeYQXK/9OMiYnW6r1uA7wHvA94O3AwcHRFPr/844COS/pzkYqefi4i/zFJnXtyD\naLcOcPGYP9jdj7AamHPCxj/YIXk+d0lZ+5C0BfB/gAuB7YAvAv+pa5MdgG2AucAfkvx8vZDkdgZz\ngeeBs3t2ewTJv9MdgFdIBphuBwC7Ar8J/A9Jb8tSa148g2ipNPvwIWD3cfbjfoTVw9Zb9X99n0Ok\nrL8A7Tvg9VkzMxaxHzAjItb/kP+qpDu63n8FODUiXk6f/xL46vrHkv6KZKbR7bKIeABA0qeA5ZKO\nTN8LkkuKvwTcK+n7wLuAhzLWOzbPINorU/YhC+cjrHrPvNj/9TtuiEBZvuD2G/vv49msJ3C8hU1v\nZtZ9u+SfdQ0OSJop6VxJP5b0NMmN0raRpAHfvxLYguQ+Ouut6Xr8PDArY6258ADRXh0yZh+ycD7C\nqrVqKRzzyMav/cGPhruXydj7eALYsee17rth9s5k/ohkeejfR8Q2wHvS17v//XR//zzgJeDnGesp\nnJeYWqgr+/DBnHd9Msn1mk4CX6/JyhOx4jppPrB4SbIk9OwL8PhZw5yBlMM+vge8Iul44BzgA8A+\nwC3p+72/OG0NvAD8QtJ2wGl99vkRSZcCjwOnA1+OiEgnGZX/IuYBop2Gzj5k4X6EVSn9QT7WKanj\n7CMiXpb0n4ELgL8Crge+RtJrgE1nEJ8DLieZEawG/hY4tGeby4BLgLeR3F/iuO6P7C1hlLrH4Yv1\ntcxU933I8TN8/wgrRNP+nUu6DfiHiLhkhO+9haRJfWFOtfhifTatsbIPWbgfYZNK0nskbS9phqSj\nSM4SvKHquoriAaJ9OoyffcjC+QibRG8Dvg88RfJ3/79ExJqpv2Wg2i/feImpRbLe9yHHz/P9IyxX\n/nc+Oi8x2XRyyz5k4XyEWbt5gGiXDjlmH7JwP8KsvTxAtMSI933Ii/sRZi3kHER7FJJ9yML5CMvR\nSknNaIzWz8q8d+gmdQuUkX3IWIfzEWY14ya1FZ59yML9CLN28QDRDh3KyT5k4X6EWUt4ianhys4+\nZOF8hFl9eIlpspWafcjC+QizdvAA0XwdSs4+ZOF+hFnzeYmpwdLsw/eB2VWc3jodiS1J7h9xZYTv\nH2FWhXF+djoH0WyVZR+ycD7CrNm8xNRQ6bJNhxouL3VzP8KsuTxANFctsg9ZuB9h1kweIJqrQ32y\nD1k4H2HWMG5SN1Adsw9ZOB9hVj7nICZP7bIPWbgfYdYsHiCaqUPNm9ODuB9h1hxeYmqYumcfsnA+\nwqw8zkFMllpnH7JwPsKsGbzE1CBNyT5k4X6EWf15gGiWxmQfsnA/wqzePEA0S4dmZR+ycD7CrKbc\npG6IpmYfsnA+wqw4zkFMhkZmH7JwP8KsnjxANEeHFjSnB3E/wqx+Ch0gJM2WdLOkH0i6T9IJfbZZ\nIOlpSXenX58ssqYmSrMPewNXV11LwdyPMKuRonMQvwI+HhHLJc0C7pL0jYh4sGe7WyPi0IJrabLG\nZx+ycD5isknzF8OcE2DrreCZF2HV0ogV11Vd1yQrdICIiCeBJ9PHz0p6ANgR6B0gvKQwQFf24aiK\nSylFBCulV/sRe0WwtuqarHjJ4LD/mXD+LhtePWZnaT4eJKpTWg9C0k7AHvQ/h39/ScslXSvpHWXV\n1BCtyj5k4X7EJJpzwsaDAyTP5y6pph6Dki61kS4vfQU4MSKe7Xn7LmBuRDwvaRFwFbDbgP2c1vV0\nWUQsK6DcuunQvuxDFieTXK/pJPD1mtpv6636vz5rZrl1NJ+khcDCXPZVdA5C0ubA14HrI+LMDNs/\nBrw7Itb2vD5xOYg2Zx+ycD5ickhHLodL37XpO4tviLhuUfkVtUfdcxAXAvcPGhwkbd/1eB+SQcvr\nzonWZh+ycD6i/STeJPFl+Mh2cPxPNn73v6+Fx8+qpjKDgmcQkg4gWSa4j2QdPYBTgHlARMR5ko4H\nPgq8DLwAnBQRm6y3T+gM4kbgogiuqLqWKkn8LbAryUxi0pbaWkvid4ClwCXAqTD/oKTnMGsmvLQO\nlrwL3vehCG6uuNRGG+dnpy+1UVNtuO9DXnz/iHaReBPwd8B8oBPR/wQMid8ELgX2ikjOhrTh1X2J\nyUYzEdmHLCJ4CTgc+FOJ/aqux0aXzhruBR4F9hw0OABEcBNwPvCPEjNKKtG6eAZRQ+mpnQ8CR7k5\nu4HEoSRLEs5HNEzWWUOf75sB3AQsi+D0AktsLc8g2mfisg9ZOB/RTMPMGnpF8ArwYeBYiYMKKtEG\n8AyihiTOBR6L4Iyqa6kb9yOaY9RZw4B9uR8xIs8gWiTNPnwIuKzqWurI/YhmGGfW0I/7EdXwAFE/\nE519yML5iPrakGvgdJLTkv80ghdz2v2nSX5m+YrPJfEAUT8dWnzfh7y4H1E/ec8aerkfUT73IGrE\n2YfhuB9RD3n2GjJ+nvsRQ3APoj2cfRiC+xHVK3rW0I/7EeXxDKImnH0YnfMR5St71tDn852PyMgz\niHZw9mFE7keUq4pZQy/3I8rhGURNOPswHvcjilf1rKEf9yOm5xlEwzn7MD73I4pVh1lDP+5HFMsD\nRD04+5AD5yPyV3CuIS/ORxTEA0Q9dHD2IRfuR+SnrrOGXu5HFMc9iIo5+5A/9yPGU8deQxbuR/Tn\nHkSzOfuQM/cjRteUWUM/7kfkzzOICjn7UCznI7Jr6qyhl/MRm/IMormcfSiQ+xHZNHnW0Mv9iHx5\nBlEhZx+K537EYG2ZNfTjfsQGnkE0kLMP5XA/or82zRr6cT8iHx4gquPsQ0mcj9igIbmGvDgfMSYP\nENXp4OxDadyPaP+soZf7EeNzD6ICzj5UY1L7EW3uNWQx6f0I9yCax9mHCkxiP2LSZg39uB8xOs8g\nSubsQ/UmIR8x6bOGXpOcj/AMolmcfahY2/sRnjVsyv2I0XgGUTJnH+qhjf0IzxqmN4n9CM8gGsLZ\nh/poWz/Cs4Zs3I8YjgeIcjn7UCNtyEdMWK4hL85HZOQBolwdnH2olSb3IzxrGI37Edm5B1ESZx/q\nq2n9CPca8jEp/Qj3IJrB2YeaalI/wrOG/LgfMT3PIErg7EMz1Dkf4VlDMSYhH+EZRP05+9AAde1H\neNZQHPcjpuYZRAmcfWiOOvUjPGsoT5v7EZ5B1JizD81Sl36EZw3lcj+iPw8QxXP2oWGqzEc411Ap\n5yN6eIAoXgdnHxqnin6EZw3Vcj9iU+5BFMjZh2Yrqx/hXkO9tK0f4R5EfTn70GBl9CM8a6gf9yM2\n8AyiIM4+tEcR+QjPGuqtTfkIzyDqydmHlsi7H+FZQ/25H5HwDKIgzj60Sx79CM8amqcN/QjPIGrG\n2Yf2Gbcf4VlDM016P8IDRDGcfWihUfIRzjW0wsTmIzxAFKODsw+tNEw/wrOGdpjkfkShA4Sk2ZJu\nlvQDSfdJOmHAdkslPSxpuaQ9iqypaGn2YW/g6qprscKcDLwJOKnfm541tE8ETwBHAl+Q2KHqesqy\necH7/xXw8YhYLmkWcJekb0TEg+s3kLQI2DkidpW0L3AO1Pua/NNw9qHlInhJ4nDgDukTwIqDYeut\n4JkX4aB74BNHA5cAR3hgaI8IbpJe7UccnM4sWq3Us5gkXQWcFRHf7HrtHOCWiPhS+vwBYGFErOn5\n3tqfxeTsw2SR/uJ0eOYUOKPrF60/ewl+9WcRf/PZ6iqzojQxH1HoWUySlkjadpSd9+xnJ2APNs0F\n7Ais6nq+On2tiZx9mCjf3nfjwQHgjC3h/oOrqceKNmn9iCxLTNsDd0q6G7gQuDGGnHaky0tfAU6M\niGeHL/PV/ZzW9XRZRCwbdV8F6QAXR9CMcImNaeut+r8+a2a5dViZInhCerUfUbt8hKSFwMI89jXt\nABERn5T0KeBg4GjgbElXAhdExI+m+35Jm5MMDpdFRL/G7WpgTtfz2elr/Wo5bbrPq0pX9mH3qmux\nsjwzoL/wrPtPLVfnfkT6i/Oy9c8lnTrqvjKdxZTOGJ5Mv34FbAt8RdJnMnz7hcD9EXHmgPevITk7\nAEn7AU/39h8awtmHibNqKRzzyMav/cGP4PGzqqnHStb6fMS0TWpJJ5L8AP858Hngqoh4WdJmwMMR\nsfMU33sAyeUJ7iNZmw/gFGAeybhzXrrd2cAhwHPA0RFxd5991bpJLXEjcFEEV1Rdi5VHmr8Y5i5J\nlpWefQEePytixXVV12XlkHgzcBfwkQhurrqefsb52ZllgDgduDAiVvZ579ci4oFRPnhYdR4gfN8H\ns8lV9+s1FTpA1EXNB4iTgXkRHFd1LWZWPonTgQOhXv0I8MX6KpVmHzr40hpmk6yV/QgPEONz9sFs\nwrU1H+EBYnwdnH0wm3htvF6TexBjSLMPq4HdfXqrmUH9+hHuQVTH2Qcz69WafoQHiPF0cHPazLq0\nqR/hJaYROftgZlOpSz7CS0zV8H0fzGygNtzP2gPECJx9MLOMGt2P8AAxGmcfzGxaTe9HeIAYTQdn\nH8wsgybnI9ykHroOZx/MbHhV5SPcpC6Xsw9mNorG9SM8QAyvg5vTZjakJvYjvMQ0VA3OPpjZeMrO\nR3iJqTzOPpjZWJqUj/AAkZGzD2aWo0b0IzxAZOfsg5nloin9CA8Q2XVw9sHMctKEfISb1Jk+29kH\nMytG0fkIN6mL5+yDmRWltv0IDxDZdHBz2swKUOd+hJeYpv1cZx/MrHhF5SO8xFQsZx/MrHB1zEd4\ngJiCsw9mVrJa9SM8QEzN2QczK03d+hEeIKbWwdkHMytRnfIRblIP/DxnH8ysOnnlI9ykLoazD2ZW\npcr7ER4gBuvg5rSZVaQO/QgvMfX9LGcfzKwexs1HeIkpf84+mFktVJmP8ADRw9kHM6uhSvoRHiA2\n5eyDmdVKVf0IDxCb6uDsg5nVTBX5CDepN/oMZx/MrN6GzUe4SZ0fZx/MrO5K60d4gNhYBzenzazG\nyuxHeInp1f07+2BmzZE1H+Elpnw4+2BmjVFGPsIDBM4+mFljFdqP8ACRcPbBzBqn6H6EB4hEB2cf\nzKyBisxHTHyT2tkHM2uDQfkIN6nH4+yDmbVB7v0IDxBuTptZCxTRjyh0gJB0gaQ1ku4d8P4CSU9L\nujv9KvVKhWn2YW/g6jI/18ysCHn3IzYfv6QpXQScRRLmGOTWiDi04DoGcfbBzFolgpskzoev3yD9\n/Zpx9lXoDCIivg08Nc1mpdwlbpMPdfbBzFprzzvh1t3guoPH2UsdehD7S1ou6VpJ7yjxc519MLOW\n2uFj8JmZ4+6l6CWm6dwFzI2I5yUtAq4Cdhu0saTTup4ui4hlY3x2B2cfzKxlJC2EXd4Op42/r6Jz\nEJLmAV+LiHdm2PYx4N0RsbbPe7nlIJx9MLM2kxbdANf/VvqMOucgxIA+g6Ttux7vQzJgbTI4FMDZ\nBzNrsVVL4ZhHxt1LoUtMki4HFgJvkPQ4cCqwJRARcR7w25I+CrwMvAAcXmQ9XTokZ1iZmbVOxIrr\npPnA4iXAIaPuZ+IuteH7PpjZJPGlNobj7IOZWQZVn8VUqq7sw1EVl2JmVnuTNoNw9sHMLKNJGyA6\nOPtgZpbJxDSpnX0ws0nkJnU2zj6YmQ1hkgaIDr4wn5lZZhOxxOTsg5lNKi8xTc/ZBzOzIbU+B+Hs\ng5nZaCZhBuHsg5nZCCZhgOjg7IOZ2dBa3aR29sHMJp2b1IM5+2BmNqK2DxAdnH0wMxtJa5eYnH0w\nM/MS0yDOPpiZjaGVOQhnH8zMxtfWGYSzD2ZmY2rrANHB2Qczs7G0rknt7IOZ2QZuUm/M2Qczsxy0\ncYDo4OyDmdnYWrXE5OyDmdnGvMS0gbMPZmY5aU0OwtkHM7N8tWkG4eyDmVmO2jRAdHD2wcwsN61o\nUjv7YGbWn5vUzj6YmeWuLQNEB2cfzMxy1fglJmcfzMwGm/QlJmcfzMwK0OgchLMPZmbFafoMwtkH\nM7OCNH2A6ODsg5lZIRrbpHb2wcxsepPapHb2wcysQE0eIDo4+2BmVphGLjE5+2Bmls0kLjE5+2Bm\nVrDG5SCcfTAzK0cTZxDOPpiZlaCJA0QHZx/MzArXqCY1xGtx9sHMLLNJalI7+2BmVpJCBwhJF0ha\nI+neKbZZKulhScsl7THNLjs4+2BmVoqiZxAXAb816E1Ji4CdI2JX4FjgnGn2tzdwdX7l5U/Swqpr\nyMJ15qsJdTahRnCddVLoABER3waemmKTw4BL021vB14vafvBmx//HMx/b541FmBh1QVktLDqAjJa\nWHUBGS2suoAMFlZdQEYLqy4go4VVF1C0qnsQOwKrup6vTl8b4O/mwP5nSvMXF1yXmdnEq3qAGMH5\nu8DcJVVXYWbWdoWf5ippHvC1iHhnn/fOAW6JiC+lzx8EFkTEmj7bNuN8XDOzmhn1NNcyLrWh9Kuf\na4DjgS9J2g94ut/gAKP/Ac3MbDSFDhCSLidp5LxB0uPAqcCWQETEeRFxnaTFkh4BngOOLrIeMzPL\nrjFJajMzK1etmtQFBOsKMV2dkhZIelrS3enXJ8uuMa1jtqSbJf1A0n2SThiwXWXHNEuNdTiekl4j\n6XZJ96S1/uWA7Sr9+5mlzjocz65aNktruGbA+5X/e0/rGFhnXY6npB9L+n76//6OAdsMdzwjojZf\nwIHAHsC9A95fBFybPt4XuK2mdS4ArqnB8dwB2CN9PAt4CHh7nY5pxhrrcjxfm/53BnAbcECdjuUQ\nddbieKa1nAR8oV89dTmeGeqsxfEEHgW2neL9oY9nrWYQkXuwrhgZ6oTBjfnSRMSTEbE8ffws8ACb\n5kwqPaYZa4R6HM/n04evIZl99/4dqMvfz+nqhBocT0mzgcXA5wdsUovjmaFOqMHxJKlhqp/pQx/P\nWg0QGQwZrKvU/uk07lpJ76i6GEk7kcx6eu+jUZtjOkWNUIPjmS4z3AM8CSyLiPt7NqnFscxQJ9Tg\neAKfBT4BAy/dX4vjyfR1Qj2OZwD/JOlOScf0eX/o49m0AaIp7gLmRsQewNnAVVUWI2kW8BXgxPS3\n9NqZpsZaHM+IWBcRewKzgfdIWlBFHdPJUGflx1PS+4E16exxqlPhK5WxzsqPZ+qAiNiLZLZzvKQD\nx91h0waI1cCcruez09dqJSKeXT/Nj4jrgS0kbVdFLZI2J/nBe1lE9LvQYeXHdLoa63Q80xp+AVxL\ncvHIbpUfy26D6qzJ8TwAOFTSo8AXgfdKurRnmzocz2nrrMnxJCKeSP/7M+CrwD49mwx9POs4QEwX\nrDsSYLpgXQkG1tm9ridpH5LTideWVViPC4H7I+LMAe/X4ZhOWWMdjqekN0p6ffp4JvAfgOU9m1V+\nLLPUWYfjGRGnRMTciHgr8LvAzRFxZM9mlR/PLHXW4XhKem06C0fS64CDgRU9mw19PMtIUmemhgTr\npqsT+G1JHwVeBl4ADq+ozgOA/wrcl65JB3AKMI+aHNMsNVKP4/lm4BJJ6xuBl0XENyUdS02OZdY6\nqcfx7KuGx7OvGh7P7YGvKrkk0ebAP0bEN8Y9ng7KmZlZX3VcYjIzsxrwAGFmZn15gDAzs748QJiZ\nWV8eIMzMrC8PEGZm1pcHCDMz68sDhJmZ9eUBwmxEkvZOb9CypaTXSVpRhyv3muXFSWqzMUj6NDAz\n/VoVEX9dcUlmufEAYTYGSVsAd5Jcg+fXw/+grEW8xGQ2njeS3Cp1a2Crimsxy5VnEGZjkHQ1yX0C\n/h3wlohYUnFJZrmp1eW+zZpE0hHASxFxhaTNgO9IWhgRyyouzSwXnkGYmVlf7kGYmVlfHiDMzKwv\nDxBmZtaXBwgzM+vLA4SZmfXlAcLMzPryAGFmZn15gDAzs77+P1veGKlwR6PMAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0xb76c54c>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.plot([1, 2, 3, 4, 5], [1, 3, 2, 2.5, 1.5], 'o-', label='graph')\n",
+    "plt.xlabel('x')\n",
+    "plt.ylabel('y')\n",
+    "plt.title('Simple plot')\n",
+    "plt.legend(loc='best')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/tests/sanitize_defaults.cfg
+++ b/tests/sanitize_defaults.cfg
@@ -1,0 +1,16 @@
+[Dates and times]
+regex: \d\d\d\d-\d\d-\d\d
+replace: DATESTAMP
+
+regex: \d\d-\d\d-\d\d\d\d
+replace: DATESTAMP
+
+regex: \d\d:\d\d
+replace: TIMESTAMP
+
+regex: \d\d:\d\d:\d\d
+replace: TIMESTAMP
+
+[Memory addresses]
+regex: 0x[0-9a-fA-F]+
+replace: MEMORY_ADDRESS

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -4,7 +4,7 @@ import textwrap
 from pytest_validate_nb.plugin import *
 
 
-def test_read_sanitize_patterns():
+def test_get_sanitize_patterns():
     file_contents = textwrap.dedent("""
         [Section1]
         regex: foo
@@ -18,7 +18,7 @@ def test_read_sanitize_patterns():
         replace: bar2
         """)
 
-    patterns = read_sanitize_patterns(file_contents)
+    patterns = get_sanitize_patterns(file_contents)
     assert patterns == {'foo': 'bar2',
                        'quux': '42',
                        }

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,0 +1,24 @@
+import sys
+sys.path.append('..')
+import textwrap
+from pytest_validate_nb.plugin import *
+
+
+def test_read_sanitize_patterns():
+    file_contents = textwrap.dedent("""
+        [Section1]
+        regex: foo
+        replace: bar1
+
+        regex: quux
+        replace: 42
+
+        [Section2 (overwrites regex 'foo')]
+        regex: foo
+        replace: bar2
+        """)
+
+    patterns = read_sanitize_patterns(file_contents)
+    assert patterns == {'foo': 'bar2',
+                       'quux': '42',
+                       }


### PR DESCRIPTION
Mostly this gets rid of reading sanitization files with ConfigParser so that we can have multiple regex-replace pairs in the same section. It also adds a couple of tests (fairly minimal at the moment; these will have to be expanded).